### PR TITLE
[feat]: add class colored background textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ This Addon aims to help navigate clunky & cluttered UI for the recently added Gr
 - Filter Applicants by:
     - Player Class
     - Selected Roles
-
 - Filter Premade Groups by:
     - Number of Members
     - Number of Tanks
     - Number of Healers
     - Number of DPS
 - Auto hide delisted entries
+- Class colored role icons
 
 ### Images:
 
-![ui_image](https://github.com/user-attachments/assets/295f60b4-ac96-4125-9189-4b44e41fa8b4)
+![ui_image](https://github.com/user-attachments/assets/71da559a-cb65-4907-9fdf-5fb157caebe9)
 
 
 *Inspired by retail's "Premade Group Filter" addon*


### PR DESCRIPTION
- replaces the blizzard role badges with badges that show the class color of each group member.
    - only applies to group finder entries for 5 man groups