### PR TITLE
[fixes]: Fix various Lua errors and UI iconsitencies 

### DIFF
--- a/AdvancedLFGFilters/AdvancedLFGFilters.lua
+++ b/AdvancedLFGFilters/AdvancedLFGFilters.lua
@@ -380,6 +380,17 @@ function LFGListHookModule.SetupModifiedEntryFrames()
         fontStringPool:Release(self.ListingNote)
         self.ListingNote = nil;
     end
+
+    -- fix for `nil` resultInfo blizzard error. Occurs when event received just after `C_LFGList.Search`
+    hooksecurefunc("LFGBrowseSearchEntry_Init", function(entry)
+        local ModifiedEventHandler = function(self, event, resultID)
+            if event ~= "LFG_LIST_SEARCH_RESULT_UPDATED"
+            or self.resultID ~= resultID
+            or not C_LFGList.GetSearchResultInfo(resultID) then return;
+            else LFGBrowseSearchEntry_OnEvent(self, event, resultID) end;
+        end
+        entry:SetScript("OnEvent", ModifiedEventHandler)
+    end)
     --------------------------------------------------------------------------------
     -- Entry frame data display modifications
     --------------------------------------------------------------------------------

--- a/AdvancedLFGFilters/AdvancedLFGFilters.lua
+++ b/AdvancedLFGFilters/AdvancedLFGFilters.lua
@@ -314,7 +314,7 @@ function LFGListHookModule.SetupModifiedEntryFrames()
         if not resultData then return end;
         local isSolo = resultData.numMembers == 1
         local leaderInfo = C_LFGList.GetSearchResultLeaderInfo(self.resultID)
-        if leaderInfo.level and leaderInfo.classFilename then
+        if leaderInfo and leaderInfo.level and leaderInfo.classFilename then
             self.Level:SetText(LVL_TEXT_PATTERN:format(leaderInfo.level));
             self.Level:Show()
             self.Level:SetPoint("BOTTOMLEFT", self.Name, "BOTTOMRIGHT", 2, 0)

--- a/AdvancedLFGFilters/AdvancedLFGFilters.lua
+++ b/AdvancedLFGFilters/AdvancedLFGFilters.lua
@@ -305,6 +305,7 @@ function LFGListHookModule.SetupModifiedEntryFrames()
         if self.DataDisplay.Comment:IsShown() then
             -- use blizz-like layout for `Custom` category entries
             EntryModMixin.Reset(self)
+            self.NewPlayerFriendlyIcon:SetPoint("LEFT", self.Name, "RIGHT", 2, 0)
             local r,g,b = NORMAL_FONT_COLOR:GetRGB()
             self.DataDisplay.Comment:SetTextColor(r, g, b, .9)
             return;


### PR DESCRIPTION
### In this PR:
**[minor][ui]: fix `NewPlayerFriendlyIcon` overlapping Comment in Custom activities**

- icon now aligned to the right of the player name


**[minor][hotfix]: check for `nil` return from `GetSearchResultLeaderInfo`**

- fixes rare lua error: "attempt to index local 'leaderInfo' (a nil value)"


**[hotfix]: patch nil index error in blizzard code**

- this fix patches an error in blizzard code relating to swapping categories in the group finder
- resolves issues related to the lua errors reading "attempt to index local 'searchResultInfo' (a nil value)"


**[dev][refactor]: use the EventFrame's inherited CallbackRegistry for handling event hooks**

- incurs the overhead of all the registry lookups and function calls. but improves dx and maintainability


**[fix]: entries no longer gray out as if they were delisted on external refreshes**

- issue would only occur when external addons like LFGBulletinBoard would refresh the results.
- issue was caused by missmatch between last search filters and currently selected dropdown filters.